### PR TITLE
Adds test parametrization fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,3 +180,42 @@ def data_files():
         A `SampleDataFiles` object.
     """
     return SampleDataFiles()
+
+
+# .............................................................................
+def pytest_generate_tests(metafunc):
+    """Pytest function for generating tests
+
+    Args:
+        metafunc (:obj:`pytest.Metafunc`): Pytest metafunc object passed to
+            test hook.
+
+    Note:
+        * We are catching this function to parameterize tests here in a central
+            location rather than for each test instance
+    """
+    df = data_files()
+    # Tuples of (fixture name, parameterization lists)
+    fixture_tuples = [
+        ('invalid_ancestral_distribution_package',
+            df.get_ancestral_distribution_packages(False)),
+        ('invalid_ancestral_state_package',
+            df.get_ancestral_state_packages(False)),
+        ('invalid_csv_alignment', df.get_alignments('csv', False)),
+        ('invalid_json_alignment', df.get_alignments('json', False)),
+        ('invalid_phylip_alignment', df.get_alignments('phylip', False)),
+        ('invalid_table_alignment', df.get_alignments('table', False)),
+        ('valid_ancestral_distribution_package',
+            df.get_ancestral_distribution_packages(True)),
+        ('valid_ancestral_state_package',
+            df.get_ancestral_state_packages(True)),
+        ('valid_csv_alignment', df.get_alignments('csv', True)),
+        ('valid_json_alignment', df.get_alignments('json', True)),
+        ('valid_newick_tree', df.get_trees('newick', True)),
+        ('valid_nexus_tree', df.get_trees('nexus', True)),
+        ('valid_phylip_alignment', df.get_alignments('phylip', True)),
+        ('valid_table_alignment', df.get_alignments('table', True))
+    ]
+    for fixture_name, fixture_values in fixture_tuples:
+        if fixture_name in metafunc.fixturenames:
+            metafunc.parametrize(fixture_name, fixture_values)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,7 +194,7 @@ def pytest_generate_tests(metafunc):
         * We are catching this function to parameterize tests here in a central
             location rather than for each test instance
     """
-    df = data_files()
+    df = SampleDataFiles()
     # Tuples of (fixture name, parameterization lists)
     fixture_tuples = [
         ('invalid_ancestral_distribution_package',

--- a/tests/test_ancestral_state/test_anc_dp.py
+++ b/tests/test_ancestral_state/test_anc_dp.py
@@ -23,12 +23,13 @@ class Test_calculate_continuous_ancestral_states(object):
     """Tests ancestral state reconstruction.
     """
     # .....................................
-    def test_package_invalid(self, data_files):
+    def test_package_invalid(self, invalid_ancestral_state_package):
         """Test calculate_continusous_ancestral_states with invalid data.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            invalid_ancestral_state_package (pytest.fixture): A parameterized
+                pytest fixture defined in conftest.py that provides an invalid
+                test package.
 
         Note:
             * This test will need to evolve as the output format changes.  It
@@ -41,58 +42,58 @@ class Test_calculate_continuous_ancestral_states(object):
                 specified file extension.
         """
         # Get the data files
-        packages = data_files.get_ancestral_state_packages(False)
-        assert len(packages) > 0
-        for tree_filename, alignment_filename, results_filename in packages:
-            # Process the tree file
-            _, tree_ext = os.path.splitext(tree_filename)
-            if tree_ext == '.nex':
-                tree_schema = 'nexus'
-            elif tree_ext == '.xml':
-                tree_schema = 'nexml'
-            elif tree_ext == '.tre':
-                tree_schema = 'newick'
-            else:
-                raise IOError(
-                    'Cannot handle tree with extension: {}'.format(tree_ext))
-            tree = dendropy.Tree.get(path=tree_filename, schema=tree_schema)
+        (tree_filename, alignment_filename, results_filename
+         ) = invalid_ancestral_state_package
+        # Process the tree file
+        _, tree_ext = os.path.splitext(tree_filename)
+        if tree_ext == '.nex':
+            tree_schema = 'nexus'
+        elif tree_ext == '.xml':
+            tree_schema = 'nexml'
+        elif tree_ext == '.tre':
+            tree_schema = 'newick'
+        else:
+            raise IOError(
+                'Cannot handle tree with extension: {}'.format(tree_ext))
+        tree = dendropy.Tree.get(path=tree_filename, schema=tree_schema)
 
-            # Process the alignment file
-            _, align_ext = os.path.splitext(alignment_filename)
-            if align_ext == '.csv':
-                with open(alignment_filename) as align_file:
-                    sequences, headers = data_readers.read_csv_alignment_flo(
-                        align_file)
-            elif align_ext == '.json':
-                with open(alignment_filename) as align_file:
-                    sequences, headers = data_readers.read_json_alignment_flo(
-                        align_file)
-            elif align_ext == '.phylip':
-                with open(alignment_filename) as align_file:
-                    sequences = data_readers.read_phylip_alignment_flo(
-                        align_file)
-            elif align_ext == '.tbl':
-                with open(alignment_filename) as align_file:
-                    sequences = data_readers.read_table_alignment_flo(
-                        align_file)
-            else:
-                raise IOError(
-                    'Cannot handle alignments with extension: {}'.format(
-                        align_ext))
+        # Process the alignment file
+        _, align_ext = os.path.splitext(alignment_filename)
+        if align_ext == '.csv':
+            with open(alignment_filename) as align_file:
+                sequences, headers = data_readers.read_csv_alignment_flo(
+                    align_file)
+        elif align_ext == '.json':
+            with open(alignment_filename) as align_file:
+                sequences, headers = data_readers.read_json_alignment_flo(
+                    align_file)
+        elif align_ext == '.phylip':
+            with open(alignment_filename) as align_file:
+                sequences = data_readers.read_phylip_alignment_flo(
+                    align_file)
+        elif align_ext == '.tbl':
+            with open(alignment_filename) as align_file:
+                sequences = data_readers.read_table_alignment_flo(
+                    align_file)
+        else:
+            raise IOError(
+                'Cannot handle alignments with extension: {}'.format(
+                    align_ext))
 
-            char_mtx = data_readers.get_character_matrix_from_sequences_list(
-                        sequences)
-            # Run analysis
-            with pytest.raises(Exception):
-                anc_dp.calculate_continuous_ancestral_states(tree, char_mtx)
+        char_mtx = data_readers.get_character_matrix_from_sequences_list(
+                    sequences)
+        # Run analysis
+        with pytest.raises(Exception):
+            anc_dp.calculate_continuous_ancestral_states(tree, char_mtx)
 
     # .....................................
-    def test_package_valid(self, data_files):
+    def test_package_valid(self, valid_ancestral_state_package):
         """Tests the calculate_continusous_ancestral_states method.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            valid_ancestral_state_package (pytest.fixture): A parameterized
+                pytest fixture defined in conftest.py that provides a valid
+                test package.
 
         Note:
             * This test will need to evolve as the output format changes.  It
@@ -107,81 +108,81 @@ class Test_calculate_continuous_ancestral_states(object):
                 found.
         """
         # Get the data files
-        packages = data_files.get_ancestral_state_packages(True)
-        assert len(packages) > 0
-        for tree_filename, alignment_filename, results_filename in packages:
-            # Process the tree file
-            _, tree_ext = os.path.splitext(tree_filename)
-            if tree_ext == '.nex':
-                tree_schema = 'nexus'
-            elif tree_ext == '.xml':
-                tree_schema = 'nexml'
-            elif tree_ext == '.tre':
-                tree_schema = 'newick'
-            else:
-                raise IOError(
-                    'Cannot handle tree with extension: {}'.format(tree_ext))
-            # tree = dendropy.Tree.get(path=tree_filename, schema=tree_schema)
-            tree = TreeWrapper.get(path=tree_filename, schema=tree_schema)
+        (tree_filename, alignment_filename, results_filename
+         ) = valid_ancestral_state_package
 
-            # Process the alignment file
-            _, align_ext = os.path.splitext(alignment_filename)
-            if align_ext == '.csv':
-                with open(alignment_filename) as align_file:
-                    sequences, headers = data_readers.read_csv_alignment_flo(
-                        align_file)
-            elif align_ext == '.json':
-                with open(alignment_filename) as align_file:
-                    sequences, headers = data_readers.read_json_alignment_flo(
-                        align_file)
-            elif align_ext == '.phylip':
-                with open(alignment_filename) as align_file:
-                    sequences = data_readers.read_phylip_alignment_flo(
-                        align_file)
-            elif align_ext == '.tbl':
-                with open(alignment_filename) as align_file:
-                    sequences = data_readers.read_table_alignment_flo(
-                        align_file)
-            else:
-                raise IOError(
-                    'Cannot handle alignments with extension: {}'.format(
-                        align_ext))
+        # Process the tree file
+        _, tree_ext = os.path.splitext(tree_filename)
+        if tree_ext == '.nex':
+            tree_schema = 'nexus'
+        elif tree_ext == '.xml':
+            tree_schema = 'nexml'
+        elif tree_ext == '.tre':
+            tree_schema = 'newick'
+        else:
+            raise IOError(
+                'Cannot handle tree with extension: {}'.format(tree_ext))
+        # tree = dendropy.Tree.get(path=tree_filename, schema=tree_schema)
+        tree = TreeWrapper.get(path=tree_filename, schema=tree_schema)
 
-            char_mtx = data_readers.get_character_matrix_from_sequences_list(
-                sequences)
-            # Run analysis
-            _, anc_mtx = anc_dp.calculate_continuous_ancestral_states(
-                tree, char_mtx, calc_std_err=True, sum_to_one=False)
+        # Process the alignment file
+        _, align_ext = os.path.splitext(alignment_filename)
+        if align_ext == '.csv':
+            with open(alignment_filename) as align_file:
+                sequences, headers = data_readers.read_csv_alignment_flo(
+                    align_file)
+        elif align_ext == '.json':
+            with open(alignment_filename) as align_file:
+                sequences, headers = data_readers.read_json_alignment_flo(
+                    align_file)
+        elif align_ext == '.phylip':
+            with open(alignment_filename) as align_file:
+                sequences = data_readers.read_phylip_alignment_flo(
+                    align_file)
+        elif align_ext == '.tbl':
+            with open(alignment_filename) as align_file:
+                sequences = data_readers.read_table_alignment_flo(
+                    align_file)
+        else:
+            raise IOError(
+                'Cannot handle alignments with extension: {}'.format(
+                    align_ext))
 
-            # New testing method
-            # (For now) assume that results file is csv with row headers for
-            #    node labels and column headers for variables
-            results = []
-            h = None
-            with open(results_filename) as results_file:
-                for line in results_file:
-                    if h is None:
-                        # Get headers
-                        h = line.strip().split(',')[1:]
-                    else:
-                        # Add result (without label) to list
-                        node_result = [
-                            float(i) for i in line.strip().split(',')[1:]]
-                        results.append(np.array(node_result, dtype=float))
+        char_mtx = data_readers.get_character_matrix_from_sequences_list(
+            sequences)
+        # Run analysis
+        _, anc_mtx = anc_dp.calculate_continuous_ancestral_states(
+            tree, char_mtx, calc_std_err=True, sum_to_one=False)
 
-            # Look for all results (only maximum likelihood)
-            for row in anc_mtx.data[:, :, 0]:
-                found = False
-                for i in range(len(results)):
-                    # Allow for some wiggle room with decimal precision
-                    if np.all(np.isclose(row, results[i])):
-                        found = True
-                        results.pop(i)
-                        break
-                if not found:
-                    raise Exception(
-                        'Could not find expected result: {} in results'.format(
-                            row))
+        # New testing method
+        # (For now) assume that results file is csv with row headers for
+        #    node labels and column headers for variables
+        results = []
+        h = None
+        with open(results_filename) as results_file:
+            for line in results_file:
+                if h is None:
+                    # Get headers
+                    h = line.strip().split(',')[1:]
+                else:
+                    # Add result (without label) to list
+                    node_result = [
+                        float(i) for i in line.strip().split(',')[1:]]
+                    results.append(np.array(node_result, dtype=float))
+
+        # Look for all results (only maximum likelihood)
+        for row in anc_mtx.data[:, :, 0]:
+            found = False
+            for i in range(len(results)):
+                # Allow for some wiggle room with decimal precision
+                if np.all(np.isclose(row, results[i])):
+                    found = True
+                    results.pop(i)
+                    break
+            if not found:
+                raise Exception(
+                    'Could not find expected result: {} in results'.format(
+                        row))
 
 
 # .............................................................................
@@ -189,12 +190,14 @@ class Test_ancestal_distribution(object):
     """Tests ancestral distribution reconstruction.
     """
     # .....................................
-    def test_package_invalid(self, data_files):
+    def test_package_invalid(self, invalid_ancestral_distribution_package):
         """Test calculate_ancestral_distributions method with invalid data.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            invalid_ancestral_distribution_package (pytest.fixture): A pytest
+                fixture that is parametrized to provide invalid ancestral
+                distributions, one at a time, so that there are multiple test
+                functions defined for each invalid package.
 
         Note:
             * This test will need to evolve as the output format changes.  It
@@ -207,58 +210,59 @@ class Test_ancestal_distribution(object):
                 specified file extension.
         """
         # Get the data files
-        packages = data_files.get_ancestral_distribution_packages(False)
-        assert len(packages) > 0
-        for tree_filename, alignment_filename, results_filename in packages:
-            # Process the tree file
-            _, tree_ext = os.path.splitext(tree_filename)
-            if tree_ext == '.nex':
-                tree_schema = 'nexus'
-            elif tree_ext == '.xml':
-                tree_schema = 'nexml'
-            elif tree_ext == '.tre':
-                tree_schema = 'newick'
-            else:
-                raise IOError(
-                    'Cannot handle tree with extension: {}'.format(tree_ext))
-            tree = dendropy.Tree.get(path=tree_filename, schema=tree_schema)
+        (tree_filename, alignment_filename, results_filename
+         ) = invalid_ancestral_distribution_package
+        # Process the tree file
+        _, tree_ext = os.path.splitext(tree_filename)
+        if tree_ext == '.nex':
+            tree_schema = 'nexus'
+        elif tree_ext == '.xml':
+            tree_schema = 'nexml'
+        elif tree_ext == '.tre':
+            tree_schema = 'newick'
+        else:
+            raise IOError(
+                'Cannot handle tree with extension: {}'.format(tree_ext))
+        tree = dendropy.Tree.get(path=tree_filename, schema=tree_schema)
 
-            # Process the alignment file
-            _, align_ext = os.path.splitext(alignment_filename)
-            if align_ext == '.csv':
-                with open(alignment_filename) as align_file:
-                    sequences, headers = data_readers.read_csv_alignment_flo(
-                        align_file)
-            elif align_ext == '.json':
-                with open(alignment_filename) as align_file:
-                    sequences, headers = data_readers.read_json_alignment_flo(
-                        align_file)
-            elif align_ext == '.phylip':
-                with open(alignment_filename) as align_file:
-                    sequences = data_readers.read_phylip_alignment_flo(
-                        align_file)
-            elif align_ext == '.tbl':
-                with open(alignment_filename) as align_file:
-                    sequences = data_readers.read_table_alignment_flo(
-                        align_file)
-            else:
-                raise IOError(
-                    'Cannot handle alignments with extension: {}'.format(
-                        align_ext))
+        # Process the alignment file
+        _, align_ext = os.path.splitext(alignment_filename)
+        if align_ext == '.csv':
+            with open(alignment_filename) as align_file:
+                sequences, headers = data_readers.read_csv_alignment_flo(
+                    align_file)
+        elif align_ext == '.json':
+            with open(alignment_filename) as align_file:
+                sequences, headers = data_readers.read_json_alignment_flo(
+                    align_file)
+        elif align_ext == '.phylip':
+            with open(alignment_filename) as align_file:
+                sequences = data_readers.read_phylip_alignment_flo(
+                    align_file)
+        elif align_ext == '.tbl':
+            with open(alignment_filename) as align_file:
+                sequences = data_readers.read_table_alignment_flo(
+                    align_file)
+        else:
+            raise IOError(
+                'Cannot handle alignments with extension: {}'.format(
+                    align_ext))
 
-            char_mtx = data_readers.get_character_matrix_from_sequences_list(
-                        sequences)
-            # Run analysis
-            with pytest.raises(Exception):
-                anc_dp.calculate_ancestral_distributions(tree, char_mtx)
+        char_mtx = data_readers.get_character_matrix_from_sequences_list(
+                    sequences)
+        # Run analysis
+        with pytest.raises(Exception):
+            anc_dp.calculate_ancestral_distributions(tree, char_mtx)
 
     # .....................................
-    def test_package_valid(self, data_files):
+    def test_package_valid(self, valid_ancestral_distribution_package):
         """Tests the calculate_ancestral_distributions method.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            invalid_ancestral_distribution_package (pytest.fixture): A pytest
+                fixture that is parametrized to provide invalid ancestral
+                distributions, one at a time, so that there are multiple test
+                functions defined for each invalid package.
 
         Raises:
             IOError: When the tree or alignment cannot be loaded for the
@@ -267,98 +271,97 @@ class Test_ancestal_distribution(object):
                 found.
         """
         # Get the data files
-        packages = data_files.get_ancestral_distribution_packages(True)
-        assert len(packages) > 0
-        for tree_filename, alignment_filename, results_filename in packages:
-            # Process the tree file
-            _, tree_ext = os.path.splitext(tree_filename)
-            if tree_ext == '.nex':
-                tree_schema = 'nexus'
-            elif tree_ext == '.xml':
-                tree_schema = 'nexml'
-            elif tree_ext == '.tre':
-                tree_schema = 'newick'
-            else:
-                raise IOError(
-                    'Cannot handle tree with extension: {}'.format(tree_ext))
-            # tree = dendropy.Tree.get(path=tree_filename, schema=tree_schema)
-            tree = TreeWrapper.get(path=tree_filename, schema=tree_schema)
+        (tree_filename, alignment_filename, results_filename
+         ) = valid_ancestral_distribution_package
+        # Process the tree file
+        _, tree_ext = os.path.splitext(tree_filename)
+        if tree_ext == '.nex':
+            tree_schema = 'nexus'
+        elif tree_ext == '.xml':
+            tree_schema = 'nexml'
+        elif tree_ext == '.tre':
+            tree_schema = 'newick'
+        else:
+            raise IOError(
+                'Cannot handle tree with extension: {}'.format(tree_ext))
+        # tree = dendropy.Tree.get(path=tree_filename, schema=tree_schema)
+        tree = TreeWrapper.get(path=tree_filename, schema=tree_schema)
 
-            # Process the alignment file
-            _, align_ext = os.path.splitext(alignment_filename)
-            if align_ext == '.csv':
-                with open(alignment_filename) as align_file:
-                    sequences, headers = data_readers.read_csv_alignment_flo(
-                        align_file)
-            elif align_ext == '.json':
-                with open(alignment_filename) as align_file:
-                    sequences, headers = data_readers.read_json_alignment_flo(
-                        align_file)
-            elif align_ext == '.phylip':
-                with open(alignment_filename) as align_file:
-                    sequences = data_readers.read_phylip_alignment_flo(
-                        align_file)
-            elif align_ext == '.tbl':
-                with open(alignment_filename) as align_file:
-                    sequences = data_readers.read_table_alignment_flo(
-                        align_file)
-            else:
-                raise IOError(
-                    'Cannot handle alignments with extension: {}'.format(
-                        align_ext))
+        # Process the alignment file
+        _, align_ext = os.path.splitext(alignment_filename)
+        if align_ext == '.csv':
+            with open(alignment_filename) as align_file:
+                sequences, headers = data_readers.read_csv_alignment_flo(
+                    align_file)
+        elif align_ext == '.json':
+            with open(alignment_filename) as align_file:
+                sequences, headers = data_readers.read_json_alignment_flo(
+                    align_file)
+        elif align_ext == '.phylip':
+            with open(alignment_filename) as align_file:
+                sequences = data_readers.read_phylip_alignment_flo(
+                    align_file)
+        elif align_ext == '.tbl':
+            with open(alignment_filename) as align_file:
+                sequences = data_readers.read_table_alignment_flo(
+                    align_file)
+        else:
+            raise IOError(
+                'Cannot handle alignments with extension: {}'.format(
+                    align_ext))
 
-            char_mtx = data_readers.get_character_matrix_from_sequences_list(
-                sequences)
-            # Run analysis
-            _, anc_mtx = anc_dp.calculate_ancestral_distributions(
-                tree, char_mtx)
+        char_mtx = data_readers.get_character_matrix_from_sequences_list(
+            sequences)
+        # Run analysis
+        _, anc_mtx = anc_dp.calculate_ancestral_distributions(
+            tree, char_mtx)
 
-            # Testing method
-            # Assume that the results file is a csv with row headers for node
-            #    labels and output layer (maximum_likeliehood / standard_error)
-            #    and column headers for variables
-            ml_results = []
-            std_err_results = []
-            h = None
-            with open(results_filename) as results_file:
-                for line in results_file:
-                    if h is None:
-                        # Get headers
-                        h = line.strip().split(',')[1:]
+        # Testing method
+        # Assume that the results file is a csv with row headers for node
+        #    labels and output layer (maximum_likeliehood / standard_error)
+        #    and column headers for variables
+        ml_results = []
+        std_err_results = []
+        h = None
+        with open(results_filename) as results_file:
+            for line in results_file:
+                if h is None:
+                    # Get headers
+                    h = line.strip().split(',')[1:]
+                else:
+                    # Add result (without label) to appropriate list
+                    parts = line.strip().split(',')
+                    layer = parts[1].lower()
+                    values = np.array(
+                        [float(i) for i in parts[2:]], dtype=float)
+                    if layer == 'maximum_likelihood':
+                        ml_results.append(values)
                     else:
-                        # Add result (without label) to appropriate list
-                        parts = line.strip().split(',')
-                        layer = parts[1].lower()
-                        values = np.array(
-                            [float(i) for i in parts[2:]], dtype=float)
-                        if layer == 'maximum_likelihood':
-                            ml_results.append(values)
-                        else:
-                            std_err_results.append(values)
-            assert(len(ml_results) == len(std_err_results))
-            print('ml results')
-            print(ml_results)
-            print('std err results')
-            print(std_err_results)
+                        std_err_results.append(values)
+        assert(len(ml_results) == len(std_err_results))
+        print('ml results')
+        print(ml_results)
+        print('std err results')
+        print(std_err_results)
 
-            # Look for all results (ml and std err results should match rows)
-            for row_idx in range(anc_mtx.data.shape[0]):
-                found = False
-                # Get rows from data
-                ml_row = anc_mtx.data[row_idx, :, 0]
-                std_err_row = anc_mtx.data[row_idx, :, 1]
+        # Look for all results (ml and std err results should match rows)
+        for row_idx in range(anc_mtx.data.shape[0]):
+            found = False
+            # Get rows from data
+            ml_row = anc_mtx.data[row_idx, :, 0]
+            std_err_row = anc_mtx.data[row_idx, :, 1]
 
-                for i in range(len(ml_results)):
-                    print(ml_results[i])
-                    print(std_err_results[i])
-                    if np.all(np.isclose(ml_row, ml_results[i])) and \
-                            np.all(np.isclose(
-                                std_err_row, std_err_results[i])):
-                        found = True
-                        ml_results.pop(i)
-                        std_err_results.pop(i)
-                        break
-                if not found:
-                    raise Exception(
-                        'Could not find {}, {} in results'.format(
-                            ml_row, std_err_row))
+            for i in range(len(ml_results)):
+                print(ml_results[i])
+                print(std_err_results[i])
+                if np.all(np.isclose(ml_row, ml_results[i])) and \
+                        np.all(np.isclose(
+                            std_err_row, std_err_results[i])):
+                    found = True
+                    ml_results.pop(i)
+                    std_err_results.pop(i)
+                    break
+            if not found:
+                raise Exception(
+                    'Could not find {}, {} in results'.format(
+                        ml_row, std_err_row))

--- a/tests/test_helpers/test_data_readers.py
+++ b/tests/test_helpers/test_data_readers.py
@@ -90,91 +90,83 @@ class Test_read_csv_alignment_flo(object):
     """Tests the dr.read_csv_alignment_flo method.
     """
     # .....................................
-    def test_file_invalid(self, data_files):
+    def test_file_invalid(self, invalid_csv_alignment):
         """Tests that the invalid alignment files fail properly.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            invalid_csv_alignment (pytest.fixture): A parameterized pytest
+                fixture providing invalid csv alignment filenames.
         """
-        invalid_csv_alignments = data_files.get_alignments('csv', False)
-        for fn in invalid_csv_alignments:
-            with open(fn) as in_csv:
-                with pytest.raises(dr.AlignmentIOError):
-                    dr.read_csv_alignment_flo(in_csv)
+        with open(invalid_csv_alignment) as in_csv:
+            with pytest.raises(dr.AlignmentIOError):
+                dr.read_csv_alignment_flo(in_csv)
 
     # .....................................
-    def test_file_valid(self, data_files):
+    def test_file_valid(self, valid_csv_alignment):
         """Tests that the valid alignment files do not fail.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            valid_csv_alignment (pytest.fixture): A parameterized pytest
+                fixture providing valid csv alignment filenames.
         """
-        valid_csv_alignments = data_files.get_alignments('csv', True)
-        for fn in valid_csv_alignments:
-            with open(fn) as in_csv:
-                try:
-                    sequence_list, headers = dr.read_csv_alignment_flo(in_csv)
-                    assert len(headers) > 0
-                    assert len(sequence_list) > 0
-                    for i in sequence_list:
-                        assert isinstance(i, Sequence)
-                        assert isinstance(i.name, string_formats)
-                        assert len(i.cont_values) > 0
-                except Exception as e:
-                    print('Raised exception: {}'.format(str(e)))
-                    assert False
+        with open(valid_csv_alignment) as in_csv:
+            try:
+                sequence_list, headers = dr.read_csv_alignment_flo(in_csv)
+                assert len(headers) > 0
+                assert len(sequence_list) > 0
+                for i in sequence_list:
+                    assert isinstance(i, Sequence)
+                    assert isinstance(i.name, string_formats)
+                    assert len(i.cont_values) > 0
+            except Exception as e:
+                print('Raised exception: {}'.format(str(e)))
+                assert False
 
     # .....................................
-    def test_stringio_invalid(self, data_files):
+    def test_stringio_invalid(self, invalid_csv_alignment):
         """Tests that invalid alignment files cause the proper failure.
 
         Tests that the invalid alignment files fail properly when loaded into
         StringIO objects.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            invalid_csv_alignment (pytest.fixture): A parameterized pytest
+                fixture providing invalid csv alignment filenames.
         """
-        invalid_csv_alignments = data_files.get_alignments('csv', False)
-        for fn in invalid_csv_alignments:
-            with open(fn) as in_csv:
-                csv_stringio = StringIO()
-                csv_stringio.write(in_csv.read())
-                csv_stringio.seek(0)
-                with pytest.raises(dr.AlignmentIOError):
-                    dr.read_csv_alignment_flo(csv_stringio)
+        with open(invalid_csv_alignment) as in_csv:
+            csv_stringio = StringIO()
+            csv_stringio.write(in_csv.read())
+            csv_stringio.seek(0)
+            with pytest.raises(dr.AlignmentIOError):
+                dr.read_csv_alignment_flo(csv_stringio)
 
     # .....................................
-    def test_stringio_valid(self, data_files):
+    def test_stringio_valid(self, valid_csv_alignment):
         """Tests that alignments are read properly with valid input data.
 
         Tests that the valid alignment files do not fail when loaded into
         StringIO objects.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            valid_csv_alignment (pytest.fixture): A parameterized pytest
+                fixture providing valid csv alignment filenames.
         """
-        valid_csv_alignments = data_files.get_alignments('csv', True)
-        for fn in valid_csv_alignments:
-            with open(fn) as in_csv:
-                csv_stringio = StringIO()
-                csv_stringio.write(in_csv.read())
-                csv_stringio.seek(0)
-                try:
-                    (sequence_list, headers) = dr.read_csv_alignment_flo(
-                        csv_stringio)
-                    assert len(headers) > 0
-                    assert len(sequence_list) > 0
-                    for i in sequence_list:
-                        assert isinstance(i, Sequence)
-                        assert isinstance(i.name, string_formats)
-                        assert len(i.cont_values) > 0
-                except Exception as e:
-                    print('Raised exception: {}'.format(str(e)))
-                    assert False
+        with open(valid_csv_alignment) as in_csv:
+            csv_stringio = StringIO()
+            csv_stringio.write(in_csv.read())
+            csv_stringio.seek(0)
+            try:
+                (sequence_list, headers) = dr.read_csv_alignment_flo(
+                    csv_stringio)
+                assert len(headers) > 0
+                assert len(sequence_list) > 0
+                for i in sequence_list:
+                    assert isinstance(i, Sequence)
+                    assert isinstance(i.name, string_formats)
+                    assert len(i.cont_values) > 0
+            except Exception as e:
+                print('Raised exception: {}'.format(str(e)))
+                assert False
 
 
 # .............................................................................
@@ -182,94 +174,86 @@ class Test_read_json_alignment_flo(object):
     """Test class for the dr.read_json_alignment_flo method.
     """
     # .....................................
-    def test_file_invalid(self, data_files):
+    def test_file_invalid(self, invalid_json_alignment):
         """Tests that the invalid alignment files fail properly.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            invalid_json_alignment (pytest.fixture): A parameterized pytest
+                fixture providing invalid json alignment filenames.
         """
-        invalid_json_alignments = data_files.get_alignments('json', False)
-        for fn in invalid_json_alignments:
-            with open(fn) as in_json:
-                with pytest.raises(dr.AlignmentIOError):
-                    dr.read_json_alignment_flo(in_json)
+        with open(invalid_json_alignment) as in_json:
+            with pytest.raises(dr.AlignmentIOError):
+                dr.read_json_alignment_flo(in_json)
 
     # .....................................
-    def test_file_valid(self, data_files):
+    def test_file_valid(self, valid_json_alignment):
         """Tests that the valid alignment files do not fail.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            valid_json_alignment (pytest.fixture): A parameterized pytest
+                fixture providing valid json alignment filenames.
         """
-        valid_json_alignments = data_files.get_alignments('json', True)
-        for fn in valid_json_alignments:
-            with open(fn) as in_json:
-                try:
-                    (sequence_list, headers
-                     ) = dr.read_json_alignment_flo(in_json)
-                    if headers is not None:
-                        assert len(headers) > 0
-                    assert len(sequence_list) > 0
-                    for i in sequence_list:
-                        assert isinstance(i, Sequence)
-                        assert isinstance(i.name, string_formats)
-                        assert len(i.cont_values) > 0
-                except Exception as e:
-                    print('Raised exception: {}'.format(str(e)))
-                    assert False
+        with open(valid_json_alignment) as in_json:
+            try:
+                (sequence_list, headers
+                 ) = dr.read_json_alignment_flo(in_json)
+                if headers is not None:
+                    assert len(headers) > 0
+                assert len(sequence_list) > 0
+                for i in sequence_list:
+                    assert isinstance(i, Sequence)
+                    assert isinstance(i.name, string_formats)
+                    assert len(i.cont_values) > 0
+            except Exception as e:
+                print('Raised exception: {}'.format(str(e)))
+                assert False
 
     # .....................................
-    def test_stringio_invalid(self, data_files):
+    def test_stringio_invalid(self, invalid_json_alignment):
         """Tests that invalid alignment files fail properly.
 
         Tests that the invalid alignment files fail properly when loaded into
         StringIO objects.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            invalid_json_alignment (pytest.fixture): A parameterized pytest
+                fixture providing invalid json alignment filenames.
         """
-        invalid_json_alignments = data_files.get_alignments('json', False)
-        for fn in invalid_json_alignments:
-            with open(fn) as in_json:
-                json_stringio = StringIO()
-                json_stringio.write(in_json.read())
-                json_stringio.seek(0)
-                with pytest.raises(dr.AlignmentIOError):
-                    dr.read_json_alignment_flo(json_stringio)
+        with open(invalid_json_alignment) as in_json:
+            json_stringio = StringIO()
+            json_stringio.write(in_json.read())
+            json_stringio.seek(0)
+            with pytest.raises(dr.AlignmentIOError):
+                dr.read_json_alignment_flo(json_stringio)
 
     # .....................................
-    def test_stringio_valid(self, data_files):
+    def test_stringio_valid(self, valid_json_alignment):
         """Tests that valid JSON alignment files do not fail.
 
         Tests that the valid alignment files do not fail when loaded into
         StringIO objects.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            valid_json_alignment (pytest.fixture): A parameterized pytest
+                fixture providing valid json alignment filenames.
         """
-        valid_json_alignments = data_files.get_alignments('json', True)
-        for fn in valid_json_alignments:
-            with open(fn) as in_json:
-                json_stringio = StringIO()
-                json_stringio.write(in_json.read())
-                json_stringio.seek(0)
-                try:
-                    (sequence_list, headers
-                     ) = dr.read_json_alignment_flo(json_stringio)
-                    if headers is not None:
-                        assert len(headers) > 0
-                    assert len(sequence_list) > 0
-                    for i in sequence_list:
-                        assert isinstance(i, Sequence)
-                        assert isinstance(i.name, string_formats)
-                        assert len(i.cont_values) > 0
-                except Exception as e:
-                    print('Raised exception: {}'.format(str(e)))
-                    assert False
+        with open(valid_json_alignment) as in_json:
+            json_stringio = StringIO()
+            json_stringio.write(in_json.read())
+            json_stringio.seek(0)
+            try:
+                (sequence_list, headers
+                 ) = dr.read_json_alignment_flo(json_stringio)
+                if headers is not None:
+                    assert len(headers) > 0
+                assert len(sequence_list) > 0
+                for i in sequence_list:
+                    assert isinstance(i, Sequence)
+                    assert isinstance(i.name, string_formats)
+                    assert len(i.cont_values) > 0
+            except Exception as e:
+                print('Raised exception: {}'.format(str(e)))
+                assert False
 
 
 # .............................................................................
@@ -277,110 +261,81 @@ class Test_read_phylip_alignment_flo(object):
     """Test class for the dr.read_phylip_alignment_flo method.
     """
     # .....................................
-    def test_file_invalid(self, data_files):
+    def test_file_invalid(self, invalid_phylip_alignment):
         """Tests that the invalid alignment files fail properly.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            invalid_phylip_alignment (pytest.fixture): A parameterized pytest
+                fixture providing invalid phylip alignment filenames.
         """
-        invalid_phylip_alignments = data_files.get_alignments('phylip', False)
-        for fn in invalid_phylip_alignments:
-            with open(fn) as in_phylip:
-                with pytest.raises(dr.AlignmentIOError):
-                    dr.read_phylip_alignment_flo(in_phylip)
+        with open(invalid_phylip_alignment) as in_phylip:
+            with pytest.raises(dr.AlignmentIOError):
+                dr.read_phylip_alignment_flo(in_phylip)
 
     # .....................................
-    def test_file_valid(self, data_files):
+    def test_file_valid(self, valid_phylip_alignment):
         """Tests that the valid alignment files do not fail.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            valid_phylip_alignment (pytest.fixture): A parameterized pytest
+                fixture providing valid phylip alignment filenames.
         """
-        valid_phylip_alignments = data_files.get_alignments('phylip', True)
-        for fn in valid_phylip_alignments:
-            with open(fn) as in_phylip:
-                try:
-                    sequence_list = dr.read_phylip_alignment_flo(in_phylip)
-                    assert len(sequence_list) > 0
-                    for i in sequence_list:
-                        assert isinstance(i, Sequence)
-                        assert isinstance(i.name, string_formats)
-                        assert i.seq is not None
-                except Exception as e:
-                    print('Raised exception: {}'.format(str(e)))
-                    assert False
+        with open(valid_phylip_alignment) as in_phylip:
+            try:
+                sequence_list = dr.read_phylip_alignment_flo(in_phylip)
+                assert len(sequence_list) > 0
+                for i in sequence_list:
+                    assert isinstance(i, Sequence)
+                    assert isinstance(i.name, string_formats)
+                    assert i.seq is not None
+            except Exception as e:
+                print('Raised exception: {}'.format(str(e)))
+                assert False
 
     # .....................................
-    def test_stringio_invalid(self, data_files):
+    def test_stringio_invalid(self, invalid_phylip_alignment):
         """Test that invalid phylip alignment files cause a failure.
 
         Tests that the invalid alignment files fail properly when loaded into
         StringIO objects.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            invalid_phylip_alignment (pytest.fixture): A parameterized pytest
+                fixture providing invalid phylip alignment filenames.
         """
-        invalid_phylip_alignments = data_files.get_alignments('phylip', False)
-        for fn in invalid_phylip_alignments:
-            with open(fn) as in_phylip:
-                phylip_stringio = StringIO()
-                phylip_stringio.write(in_phylip.read())
-                phylip_stringio.seek(0)
-                with pytest.raises(dr.AlignmentIOError):
-                    dr.read_phylip_alignment_flo(phylip_stringio)
+        with open(invalid_phylip_alignment) as in_phylip:
+            phylip_stringio = StringIO()
+            phylip_stringio.write(in_phylip.read())
+            phylip_stringio.seek(0)
+            with pytest.raises(dr.AlignmentIOError):
+                dr.read_phylip_alignment_flo(phylip_stringio)
 
     # .....................................
-    def test_stringio_valid(self, data_files):
+    def test_stringio_valid(self, valid_phylip_alignment):
         """Tests that valid phylip alignment files are loaded properly.
 
         Tests that the valid alignment files do not fail when loaded into
         StringIO objects.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            valid_phylip_alignment (pytest.fixture): A parameterized pytest
+                fixture providing valid phylip alignment filenames.
         """
-        valid_phylip_alignments = data_files.get_alignments('phylip', True)
-        for fn in valid_phylip_alignments:
-            with open(fn) as in_phylip:
-                phylip_stringio = StringIO()
-                phylip_stringio.write(in_phylip.read())
-                phylip_stringio.seek(0)
-                try:
-                    sequence_list = dr.read_phylip_alignment_flo(
-                        phylip_stringio)
-                    assert len(sequence_list) > 0
-                    for i in sequence_list:
-                        assert isinstance(i, Sequence)
-                        assert isinstance(i.name, string_formats)
-                        assert i.seq is not None
-                except Exception as e:
-                    print('Raised exception: {}'.format(str(e)))
-                    assert False
-
-
-# .............................................................................
-class Test_read_phylip_continuous_alignment_flo(object):
-    """Test class for the read_phylip_continuous_alignment_flo method.
-    """
-    # .....................................
-    def test_file_invalid(self, data_files):
-        pass
-
-    # .....................................
-    def test_file_valid(self, data_files):
-        pass
-
-    # .....................................
-    def test_stringio_invalid(self, data_files):
-        pass
-
-    # .....................................
-    def test_stringio_valid(self, data_files):
-        pass
+        with open(valid_phylip_alignment) as in_phylip:
+            phylip_stringio = StringIO()
+            phylip_stringio.write(in_phylip.read())
+            phylip_stringio.seek(0)
+            try:
+                sequence_list = dr.read_phylip_alignment_flo(
+                    phylip_stringio)
+                assert len(sequence_list) > 0
+                for i in sequence_list:
+                    assert isinstance(i, Sequence)
+                    assert isinstance(i.name, string_formats)
+                    assert i.seq is not None
+            except Exception as e:
+                print('Raised exception: {}'.format(str(e)))
+                assert False
 
 
 # .............................................................................
@@ -388,85 +343,77 @@ class Test_read_table_continuous_alignment_flo(object):
     """Test class for the read_table_continuous_alignment_flo method.
     """
     # .....................................
-    def test_file_invalid(self, data_files):
+    def test_file_invalid(self, invalid_table_alignment):
         """Tests that the invalid alignment files fail properly.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            invalid_table_alignment (pytest.fixture): A parameterized pytest
+                fixture providing invalid table alignment filenames.
         """
-        invalid_table_alignments = data_files.get_alignments('table', False)
-        for fn in invalid_table_alignments:
-            with open(fn) as in_table:
-                with pytest.raises(dr.AlignmentIOError):
-                    dr.read_table_alignment_flo(in_table)
+        with open(invalid_table_alignment) as in_table:
+            with pytest.raises(dr.AlignmentIOError):
+                dr.read_table_alignment_flo(in_table)
 
     # .....................................
-    def test_file_valid(self, data_files):
+    def test_file_valid(self, valid_table_alignment):
         """Tests that the valid alignment files do not fail.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            valid_table_alignment (pytest.fixture): A parameterized pytest
+                fixture providing valid table alignment filenames.
         """
-        valid_table_alignments = data_files.get_alignments('table', True)
-        for fn in valid_table_alignments:
-            with open(fn) as in_table:
-                try:
-                    sequence_list = dr.read_table_alignment_flo(in_table)
-                    assert len(sequence_list) > 0
-                    for i in sequence_list:
-                        assert isinstance(i, Sequence)
-                        assert isinstance(i.name, string_formats)
-                        assert len(i.cont_values) > 0
-                except Exception as e:
-                    print('Raised exception: {}'.format(str(e)))
-                    assert False
+        with open(valid_table_alignment) as in_table:
+            try:
+                sequence_list = dr.read_table_alignment_flo(in_table)
+                assert len(sequence_list) > 0
+                for i in sequence_list:
+                    assert isinstance(i, Sequence)
+                    assert isinstance(i.name, string_formats)
+                    assert len(i.cont_values) > 0
+            except Exception as e:
+                print('Raised exception: {}'.format(str(e)))
+                assert False
 
     # .....................................
-    def test_stringio_invalid(self, data_files):
+    def test_stringio_invalid(self, invalid_table_alignment):
         """Tests that invalid table alignment files cause a failure.
 
         Tests that the invalid alignment files fail properly when loaded into
         StringIO objects.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            invalid_table_alignment (pytest.fixture): A parameterized pytest
+                fixture providing invalid table alignment filenames.
         """
-        invalid_table_alignments = data_files.get_alignments('table', False)
-        for fn in invalid_table_alignments:
-            with open(fn) as in_table:
-                table_stringio = StringIO()
-                table_stringio.write(in_table.read())
-                table_stringio.seek(0)
-                with pytest.raises(dr.AlignmentIOError):
-                    dr.read_table_alignment_flo(table_stringio)
+        with open(invalid_table_alignment) as in_table:
+            table_stringio = StringIO()
+            table_stringio.write(in_table.read())
+            table_stringio.seek(0)
+            with pytest.raises(dr.AlignmentIOError):
+                dr.read_table_alignment_flo(table_stringio)
 
     # .....................................
-    def test_stringio_valid(self, data_files):
+    def test_stringio_valid(self, valid_table_alignment):
         """Tests that valid table alignment files are loaded correctly.
 
         Tests that the valid alignment files do not fail when loaded into
         StringIO objects.
 
         Args:
-            data_files (pytest.fixture): A pytest fixture defined in
-                conftest.py for retrieving test data.
+            valid_table_alignment (pytest.fixture): A parameterized pytest
+                fixture providing valid table alignment filenames.
         """
-        valid_table_alignments = data_files.get_alignments('table', True)
-        for fn in valid_table_alignments:
-            with open(fn) as in_table:
-                table_stringio = StringIO()
-                table_stringio.write(in_table.read())
-                table_stringio.seek(0)
-                try:
-                    sequence_list = dr.read_table_alignment_flo(table_stringio)
-                    assert len(sequence_list) > 0
-                    for i in sequence_list:
-                        assert isinstance(i, Sequence)
-                        assert isinstance(i.name, string_formats)
-                        assert len(i.cont_values) > 0
-                except Exception as e:
-                    print('Raised exception: {}'.format(str(e)))
-                    assert False
+        with open(valid_table_alignment) as in_table:
+            table_stringio = StringIO()
+            table_stringio.write(in_table.read())
+            table_stringio.seek(0)
+            try:
+                sequence_list = dr.read_table_alignment_flo(table_stringio)
+                assert len(sequence_list) > 0
+                for i in sequence_list:
+                    assert isinstance(i, Sequence)
+                    assert isinstance(i.name, string_formats)
+                    assert len(i.cont_values) > 0
+            except Exception as e:
+                print('Raised exception: {}'.format(str(e)))
+                assert False

--- a/tests/test_lm_objects/test_tree.py
+++ b/tests/test_lm_objects/test_tree.py
@@ -49,23 +49,38 @@ class Test_TreeWrapper(object):
     they work properly.
     """
     # .....................................
-    def test_from_base_tree(self, data_files):
+    def test_from_base_newick_tree(self, valid_newick_tree):
         """Attempt to get a tree using Dendropy and then wrap it.
 
         Try to retrieve a tree using Dendropy and then send it through the
         wrapper function to determine if it produces a correctly wrapped tree.
 
         Args:
-            data_files (:obj: `pytest.fixture`): A pytest fixture that provides
-                access to test data.
+            valid_newick_tree (pytest.fixture): A parameterized pytest fixture
+                that provides valid newick trees, one at a time, to this test
+                function.
         """
-        schemas = ['newick', 'nexus']
-        for schema in schemas:
-            for tree_filename in data_files.get_trees(schema, True):
-                dendropy_tree = dendropy.Tree.get(
-                    path=tree_filename, schema=schema)
-                wrapped_tree = tree.TreeWrapper.from_base_tree(dendropy_tree)
-                assert isinstance(wrapped_tree, tree.TreeWrapper)
+        dendropy_tree = dendropy.Tree.get(
+            path=valid_newick_tree, schema='newick')
+        wrapped_tree = tree.TreeWrapper.from_base_tree(dendropy_tree)
+        assert isinstance(wrapped_tree, tree.TreeWrapper)
+
+    # .....................................
+    def test_from_base_nexus_tree(self, valid_nexus_tree):
+        """Attempt to get a tree using Dendropy and then wrap it.
+
+        Try to retrieve a tree using Dendropy and then send it through the
+        wrapper function to determine if it produces a correctly wrapped tree.
+
+        Args:
+            valid_nexus_tree (pytest.fixture): A parameterized pytest fixture
+                that provides valid nexus trees, one at a time, to this test
+                function.
+        """
+        dendropy_tree = dendropy.Tree.get(
+            path=valid_nexus_tree, schema='nexus')
+        wrapped_tree = tree.TreeWrapper.from_base_tree(dendropy_tree)
+        assert isinstance(wrapped_tree, tree.TreeWrapper)
 
     # .....................................
     def test_add_node_labels_no_prefix_no_overwrite(self):


### PR DESCRIPTION
Replaces data_files fixture in favor of pytest parameterization

## Pull Request Type
 - [X] New Feature
 
## Status
 - [X] Ready

## Description
The goal of this is to use pytest parametrization rather than the roll-your-own approach I had done initially.  Tests can be simplified to just test provided inputs rather than a list of them.

## Link(s) to issue
This closes #32 

