### PR TITLE
Change matrix storage format to zip file

### DIFF
--- a/analyses/lm_objects/matrix.py
+++ b/analyses/lm_objects/matrix.py
@@ -109,7 +109,7 @@ class Matrix(object):
         """
         with zipfile.ZipFile(flo) as zip_f:
             with zip_f.open(HEADERS_FILENAME) as obj_in:
-                my_obj = json.load(obj_in)
+                my_obj = json.loads(obj_in.read())
             data_bytes = io.BytesIO()
             data_bytes.write(zip_f.read(DATA_FILENAME))
             data_bytes.seek(0)

--- a/analyses/lm_objects/matrix.py
+++ b/analyses/lm_objects/matrix.py
@@ -113,7 +113,8 @@ class Matrix(object):
             data_bytes.write(zip_f.read(DATA_FILENAME))
             data_bytes.seek(0)
             tmp = np.load(data_bytes)
-            data = np.array(tmp[list(tmp.keys())[0]])
+            data = tmp.items()[0][1]
+            #data = np.array(tmp[list(tmp.keys())[0]])
             data_bytes.close()
 
         return cls(data, headers=my_obj[HEADERS_KEY])

--- a/analyses/lm_objects/matrix.py
+++ b/analyses/lm_objects/matrix.py
@@ -108,8 +108,7 @@ class Matrix(object):
             Matrix: The newly loaded Matrix object.
         """
         with zipfile.ZipFile(flo) as zip_f:
-            with zip_f.open(HEADERS_FILENAME) as obj_in:
-                my_obj = json.loads(obj_in.read())
+            my_obj = json.loads(zip_f.read(HEADERS_FILENAME).decode('utf-8'))
             data_bytes = io.BytesIO()
             data_bytes.write(zip_f.read(DATA_FILENAME))
             data_bytes.seek(0)

--- a/analyses/lm_objects/matrix.py
+++ b/analyses/lm_objects/matrix.py
@@ -80,7 +80,8 @@ class Matrix(object):
         # Try loading the Matrix object
         try:
             return cls.load_new(flo)
-        except:
+        except Exception as e1:
+            print(str(e1))
             # Try loading a numpy array
             try:
                 # Seek back to start of file

--- a/analyses/lm_objects/matrix.py
+++ b/analyses/lm_objects/matrix.py
@@ -10,6 +10,7 @@ Todo:
 from copy import deepcopy
 import io
 import json
+import zipfile
 
 import numpy as np
 
@@ -17,7 +18,9 @@ import numpy as np
 HEADERS_KEY = 'headers'
 DATA_KEY = 'data'
 VERSION_KEY = 'version'
-VERSION = '2.0.0'
+VERSION = '3.0.0'
+HEADERS_FILENAME = 'headers.json'
+DATA_FILENAME = 'data.npz'
 
 
 # .............................................................................
@@ -103,6 +106,35 @@ class Matrix(object):
         Returns:
             Matrix: The newly loaded Matrix object.
         """
+        with zipfile.ZipFile(flo) as zip_f:
+            with zip_f.open(HEADERS_FILENAME) as obj_in:
+                my_obj = json.load(obj_in)
+            data_bytes = io.BytesIO()
+            data_bytes.write(zip_f.read(DATA_FILENAME))
+            data_bytes.seek(0)
+            tmp = np.load(data_bytes)
+            data = tmp[list(tmp.keys())[0]]
+            data_bytes.close()
+
+        return cls(data, headers=my_obj[HEADERS_KEY])
+
+    # ...........................
+    @classmethod
+    def load_our_format_old(cls, flo):  # pragma: no cover
+        """Attempts to load a Matrix object from a file.
+
+        Note:
+            * This is obsolete and should only be used for legacy data
+
+        Args:
+            flo (file-like): A file-like object with matrix data.
+
+        Todo:
+            * Merge this into main load method.
+
+        Returns:
+            Matrix: The newly loaded Matrix object.
+        """
         header_lines = []
         data_lines = []
         do_headers = True
@@ -113,9 +145,11 @@ class Matrix(object):
                 if do_headers:
                     if str_line.startswith(DATA_KEY):
                         do_headers = False
+                        break
                     else:
                         header_lines.append(str_line)
-            except:
+            except Exception as e:
+                print(str(e))
                 data_stream.write(line)
                 # data_lines.append(line)
 
@@ -304,8 +338,8 @@ class Matrix(object):
     def save(self, flo):
         """Saves the Matrix to a file-like object.
 
-        Saves the Matrix object in a JSON / Numpy hybrid format to the
-            file-like object.
+        Saves the Matrix object in a JSON / Numpy zip file to the file-like
+        object.
 
         Args:
             flo (file-like): The file-like object to write to.
@@ -313,16 +347,19 @@ class Matrix(object):
         my_obj = {}
         my_obj[HEADERS_KEY] = self.headers
         my_obj[VERSION_KEY] = VERSION
-        try:  # pragma: no cover
-            flo.write('{}\n'.format(json.dumps(my_obj, indent=3,
-                                               default=float)))
-            flo.write('{}\n'.format(DATA_KEY))
-            np.savez_compressed(flo, self.data)
-        except:  # pragma: no cover
-            my_obj_str = '{}\n{}\n'.format(
-                json.dumps(my_obj, indent=3, default=float), DATA_KEY)
-            flo.write(bytes(my_obj_str, 'utf8'))
-            np.savez_compressed(flo, self.data)
+
+        np_bytes = io.BytesIO()
+        np.savez_compressed(np_bytes, self.data)
+        np_bytes.seek(0)
+        zip_np_str = np_bytes.getvalue()
+        np_bytes.close()
+
+        with zipfile.ZipFile(
+            flo, mode='w', compression=zipfile.ZIP_DEFLATED,
+                allowZip64=True) as zip_f:
+
+            zip_f.writestr(HEADERS_FILENAME, json.dumps(my_obj, default=float))
+            zip_f.writestr(DATA_FILENAME, zip_np_str)
 
     # ...........................
     def set_column_headers(self, headers):

--- a/analyses/lm_objects/matrix.py
+++ b/analyses/lm_objects/matrix.py
@@ -114,7 +114,7 @@ class Matrix(object):
             data_bytes.seek(0)
             tmp = np.load(data_bytes)
             data = tmp.items()[0][1]
-            #data = np.array(tmp[list(tmp.keys())[0]])
+            # data = np.array(tmp[list(tmp.keys())[0]])
             data_bytes.close()
 
         return cls(data, headers=my_obj[HEADERS_KEY])

--- a/analyses/lm_objects/matrix.py
+++ b/analyses/lm_objects/matrix.py
@@ -113,7 +113,7 @@ class Matrix(object):
             data_bytes.write(zip_f.read(DATA_FILENAME))
             data_bytes.seek(0)
             tmp = np.load(data_bytes)
-            data = tmp.items()[0][1]
+            data = tmp[tmp.files[0]]
             # data = np.array(tmp[list(tmp.keys())[0]])
             data_bytes.close()
 

--- a/analyses/lm_objects/matrix.py
+++ b/analyses/lm_objects/matrix.py
@@ -113,7 +113,7 @@ class Matrix(object):
             data_bytes.write(zip_f.read(DATA_FILENAME))
             data_bytes.seek(0)
             tmp = np.load(data_bytes)
-            data = tmp[list(tmp.keys())[0]]
+            data = np.array(tmp[list(tmp.keys())[0]])
             data_bytes.close()
 
         return cls(data, headers=my_obj[HEADERS_KEY])

--- a/tests/test_lm_objects/test_matrix.py
+++ b/tests/test_lm_objects/test_matrix.py
@@ -49,7 +49,7 @@ class Test_Matrix(object):
         mtx_bytesio.close()
 
         # Verify data and headers are the same
-        assert np.all(np.isclose(loaded_mtx.data, orig_mtx.data))
+        assert np.allclose(loaded_mtx.data, orig_mtx.data)
         assert loaded_mtx.get_headers() == orig_mtx.get_headers()
 
         # Write to temp file
@@ -59,7 +59,7 @@ class Test_Matrix(object):
             np_mtx = matrix.Matrix.load(out_f)
 
         # Verify that the data is the same
-        assert np.all(np.isclose(np_mtx.data, orig_mtx.data))
+        assert np.allclose(np_mtx.data, orig_mtx.data)
 
         # Verify load fails with empty file
         with pytest.raises(IOError):
@@ -81,7 +81,7 @@ class Test_Matrix(object):
         mtx_bytesio.close()
 
         # Verify data and headers are the same
-        assert np.all(np.isclose(loaded_mtx.data, orig_mtx.data))
+        assert np.allclose(loaded_mtx.data, orig_mtx.data)
         assert loaded_mtx.get_headers() == orig_mtx.get_headers()
 
     # .....................................
@@ -233,7 +233,7 @@ class Test_Matrix(object):
             loaded_mtx = matrix.Matrix.load(save_f)
 
         # Verify data and headers are the same
-        assert np.all(np.isclose(loaded_mtx.data, orig_mtx.data))
+        assert np.allclose(loaded_mtx.data, orig_mtx.data)
         assert loaded_mtx.get_headers() == orig_mtx.get_headers()
 
     # .....................................
@@ -339,7 +339,7 @@ class Test_Matrix(object):
             test_data = test_data.take(range(dim_lower, dim_upper), axis=i)
 
         # Check data
-        assert np.all(np.isclose(test_data, sliced_mtx.data))
+        assert np.allclose(test_data, sliced_mtx.data)
 
     # .....................................
     def test_slice_by_header(self):
@@ -356,7 +356,7 @@ class Test_Matrix(object):
         assert sliced_mtx.data.shape == (3, 3, 1)
 
         # Check that data is the second layer
-        assert np.all(np.isclose(sliced_mtx.data[:, :, 0], mtx.data[:, :, 1]))
+        assert np.allclose(sliced_mtx.data[:, :, 0], mtx.data[:, :, 1])
 
         # Check that the headers are what we expect
         assert mtx.get_row_headers() == sliced_mtx.get_row_headers()


### PR DESCRIPTION
Two files inside, headers.json - stores headers and version
data.npz - stores numpy array

## Pull Request Type
 - [x] Bug Fix
 
## Status
 - [x] Ready

## Description
Changes the matrix storage format to make more compatible and remove bug.

## Link(s) to issue
#36 
